### PR TITLE
Add the shutdown event

### DIFF
--- a/lib/AnyEvent/I3.pm
+++ b/lib/AnyEvent/I3.pm
@@ -114,6 +114,7 @@ my %events = (
     window => ($event_mask | 3),
     barconfig_update => ($event_mask | 4),
     binding => ($event_mask | 5),
+    shutdown => ($event_mask | 6),
     _error => 0xFFFFFFFF,
 );
 


### PR DESCRIPTION
The shutdown event is triggered when the ipc shuts down because of
either a restart or when i3 exits.
